### PR TITLE
Update main.js

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,11 +32,6 @@ module.exports = function (reporter, definition) {
   db = pg(reporter.options.connectionString)
 
   reporter.documentStore.provider = new Store(reporter, 'postgres', function (a) {
-    return db.result(a.text, a.values).then(function (res) {
-      return {
-        records: res.rows,
-        rowsAffected: res.rowCount
-      }
-    })
+    return db.result(a.text, a.values, res => ({records: res.rows, rowsAffected: res.rowAffected}));
   })
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,6 +32,6 @@ module.exports = function (reporter, definition) {
   db = pg(reporter.options.connectionString)
 
   reporter.documentStore.provider = new Store(reporter, 'postgres', function (a) {
-    return db.result(a.text, a.values, res => ({records: res.rows, rowsAffected: res.rowAffected}));
+    return db.result(a.text, a.values, r => ({records: r.rows, rowsAffected: r.rowAffected}));
   })
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,6 +32,6 @@ module.exports = function (reporter, definition) {
   db = pg(reporter.options.connectionString)
 
   reporter.documentStore.provider = new Store(reporter, 'postgres', function (a) {
-    return db.result(a.text, a.values, r => ({records: r.rows, rowsAffected: r.rowAffected}));
+    return db.result(a.text, a.values, r => ({records: r.rows, rowsAffected: r.rowCount}));
   })
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,14 +31,8 @@ module.exports = function (reporter, definition) {
 
   db = pg(reporter.options.connectionString)
 
-  reporter.documentStore.provider = new Store(reporter, 'postgres', function (q) {
-    for (var i = 0; i < q.values.length; i++) {
-      if (Buffer.isBuffer(q.values[i])) {
-        q.values[i] = '\\x' + q.values[i].toString('hex')
-      }
-    }
-
-    return db.result(q.text, q.values).then(function (res) {
+  reporter.documentStore.provider = new Store(reporter, 'postgres', function (a) {
+    return db.result(a.text, a.values).then(function (res) {
       return {
         records: res.rows,
         rowsAffected: res.rowCount


### PR DESCRIPTION
1. Do not use local variable `q` when you have `q` as a module-wide variable, it's just bad coding;
2. Your conversion of type `Buffer` is pointless, as `pg-promise` supports the type automatically.

Also note that when you have an object with `text` and `values`, it can be automatically treated as a Prepared Statement, i.e. you can do `d.result(a)`, but only if you use simple index variables in the query.